### PR TITLE
Add aarch64 wheel build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,15 @@ matrix:
       env: DOCKER_IMAGE=quay.io/pypa/manylinux2010_x86_64
            PLAT=manylinux2010_x86_64
            MANYLINUX=1
+    - sudo: required
+      arch: arm64-graviton2
+      group: edge
+      virt: lxd
+      services:
+        - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux2014_aarch64
+           PLAT=manylinux2014_aarch64
+           MANYLINUX=1
     - os: linux
       python: 2.7
       env:


### PR DESCRIPTION
**Package Owner**: Disha Srivastava

**PR change Details**: Added linux aarch64 wheel support.

**Testing Detail** : logs: https://travis-ci.com/github/sridish123/py-scrypt/jobs/498799061

**Peer Reviewer:** Madhukar

**Reviewer:** Shobhit